### PR TITLE
指定output: ["*.js"]后，用spm build -O path/to/customize/dist构建，生成的文件还是放在src/build下面，没有复制到指定的目录里面

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -212,7 +212,7 @@ function distConfig(options, pkg) {
           return !/\.(js|css)$/.test(src);
         },
         expand: true,
-        dest: './build/dist'
+        dest: '.build/dist'
       });
       jsmins.push({
         cwd: '.build/src',
@@ -224,7 +224,7 @@ function distConfig(options, pkg) {
           return /\.js$/.test(src);
         },
         expand: true,
-        dest: './build/dist'
+        dest: '.build/dist'
       });
       cssmins.push({
         cwd: '.build/src',
@@ -236,7 +236,7 @@ function distConfig(options, pkg) {
           return /\.css$/.test(src);
         },
         expand: true,
-        dest: './build/dist'
+        dest: '.build/dist'
       });
     }
   });


### PR DESCRIPTION
不知道这个算不算一个bug，简单修改了一下就可以复制到指定的目录里面了。

_请忽略之前的commit，对git不太熟悉，只关注最后一个commit就可以了……_
