### PR TITLE
fix output like {"js/xxx":"xxx"},after build has no dist  directory

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -265,13 +265,11 @@ function distConfig(options, pkg) {
       {
         expand: true,
         cwd: '.build/src',
-        src: '*.js',
+        src: '**/*.js',
         filter: function(src) {
-          var m = src.match(/^.*\/((.*?)-[a-z0-9]{8}\.js)$/);
-          if (!m) {
-            return false;
-          }
-          return typeof output[m[2] + '.js'] !== 'undefined';
+          return Object.keys(output).filter(function(key) {
+            return new RegExp("^.*\/" + key.replace(/(\.js|\.css)$/, '') + '-[a-z0-9]{8}\.js$').test(src);
+          }).length > 0;
         },
         dest: '.build/tmp'
       },
@@ -279,13 +277,14 @@ function distConfig(options, pkg) {
       {
         expand: true,
         cwd: '.build/src',
-        src: '*.js',
+        src: '**/*.js',
         filter: function(src) {
-          var m = src.match(/^.*\/(.*?\.js)$/);
-          if (!m) {
-            return false;
-          }
-          return typeof output[m[1]] !== 'undefined';
+          // var m = src.match(/^.*\/(.*?\.js)$/);
+          // if (!m) {
+          //   return false;
+          // }
+          // return typeof output[m[1]] !== 'undefined';
+          return false;
         },
         dest: '.build/dist'
       }
@@ -295,7 +294,7 @@ function distConfig(options, pkg) {
     jsmins = [{
       expand: true,
       cwd: '.build/tmp',
-      src: '*.js',
+      src: '**/*.js',
       dest: '.build/dist'
     }];
 
@@ -303,14 +302,12 @@ function distConfig(options, pkg) {
     cssmins = [{
       expand: true,
       cwd: '.build/tmp',
-      src: '*.css',
+      src: '**/*.css',
       filter: function(src) {
-          var m = src.match(/^.*\/((.*?)-[a-z0-9]{8}\.css)$/);
-          if (!m) {
-            return false;
-          }
-          return typeof output[m[2] + '.js'] !== 'undefined';
-        },
+        return Object.keys(output).filter(function(key) {
+          return new RegExp("^.*\/" + key.replace(/(\.js|\.css)$/, '') + '-[a-z0-9]{8}\.css$').test(src);
+        }).length > 0;
+      },
       dest: '.build/dist'
     }];
 
@@ -319,7 +316,7 @@ function distConfig(options, pkg) {
       {
         expand: true,
         cwd: '.build/tmp',
-        src: '*.css',
+        src: '**/*.css',
         filter: function(src) {
           var m = src.match(/^.*\/(.*?\.css)$/);
           if (!m) {
@@ -332,7 +329,7 @@ function distConfig(options, pkg) {
       {
         expand: true,
         cwd: '.build/src',
-        src: '*.*',
+        src: '**/*.*',
         filter: function(src) {
           return !/\.(js|css)$/.test(src);
         },


### PR DESCRIPTION
fix output like {"js/xxx":"xxx"},after build has no dist  directory
    don't move .build/src/*.js to ./build/dist when spm.hash==true