### PR TITLE
refactor(build) more expandable

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -4,12 +4,11 @@
 
 require('colorful').colorful();
 var program = require('commander');
-var co = require('co');
 var log = require('spm-log');
 var join = require('path').join;
 var exists = require('fs').existsSync;
 var readFile = require('fs').readFileSync;
-var build = require('./').build;
+var Build = require('./').Build;
 
 program
   .option('-I, --input-directory <dir>', 'input directory, default: current working directory')
@@ -68,14 +67,21 @@ var args = {
   entry: entry
 };
 
-co(build(args)).then(function() {
-  log.info('finish', info + showDiff(begin));
-  console.log();
-}, function (err) {
-  log.error(err.message);
-  log.error(err.stack);
-  process.exit(1);
-});
+new Build(args)
+  .getArgs()
+  .installDeps()
+  .parsePkg()
+  .addCleanTask()
+  .run(function(err) {
+    if (err) {
+      log.error(err.message);
+      log.error(err.stack);
+      process.exit(1);
+    }
+
+    log.info('finish', info + showDiff(begin));
+    console.log();
+  });
 
 function showDiff(time) {
   var diff = Date.now() - time;

--- a/lib/build.js
+++ b/lib/build.js
@@ -2,7 +2,7 @@
 
 require('colorful').colorful();
 
-var extname = require('path').extname;
+var debug = require('debug')('spm-build');
 var relative = require('path').relative;
 var join = require('path').join;
 var client = require('spm-client');
@@ -15,6 +15,9 @@ var spmrc = require('spmrc');
 var extend = require('extend');
 var flatten = require('flatten');
 var cdeps = require('cdeps');
+var Step = require('step.js');
+var thunkify = require('thunkify');
+var unyield = require('unyield');
 
 var _if = require('gulp-if');
 var mirror = require('gulp-mirror');
@@ -24,146 +27,194 @@ var uglify = require('gulp-uglify');
 var cssmin = require('gulp-minify-css');
 var zip = require('gulp-zip');
 
+var logArgs = require('./logArgs');
 var getArgs = require('./getArgs');
 var getFiles = require('./getFiles');
 var getDepFiles = require('./getDepFiles');
 var getExtraDeps = require('./getExtraDeps');
 var getDuplicate = require('./getDuplicate');
 var generatePackageJSON = require('./generatePackageJSON');
+var utils = require('./utils');
 
-module.exports = function* build(opt) {
-  var isFirst = opt.isFirstTime !== false;
-  var args = getArgs(opt);
-  logArgs(args);
+module.exports = Build;
 
-  // Try to generate package.json if entry is supplied
-  if (args.entry.length) {
-    generatePackageJSON(opt);
-  }
+function Build(opt) {
+  if (!(this instanceof Build)) return new Build(opt);
+  this.opt = opt || {};
+  this.plugins = new Step();
+  this.plugins.run = thunkify(this.plugins.run);
+  this.fns = this.plugins.fns;
+}
 
-  // Install dependencies
-  if (args.entry.length) {
-    var deps = flatten(args.entry.map(function(item) {
-      return cdeps(join(args.cwd, item));
-    }));
-    log.info('entry deps', deps.join(', '));
-    yield* client.install({cwd:args.cwd, registry:args.registry, name:deps, save:true});
-  } else if (args.install) {
-    yield* client.install({cwd:args.cwd, registry:args.registry});
-  }
+/**
+ * Add plugin.
+ */
+Build.prototype.use = function(fn) {
+  if (this.plugins.fns.indexOf(fn) > -1) return this;
+  var name = fn.name || '(anonymous)';
+  debug('using plugin: %s', name);
+  this.plugins.use(fn);
+  return this;
+};
 
-  // Parse package
-  var pkg = new Package(args.cwd, {
-    ignore: args.ignore,
-    skip: args.skip,
-    moduleDir: spmrc.get('install.path'),
-    entry: args.entry
-  });
-  args.pkg = pkg;
-  log.info('package', 'analyse infomation');
-  log.info('package', 'dependencies: ' + Object.keys(pkg.dependencies));
-  log.info('package', 'files: ' + Object.keys(pkg.files));
+/**
+ * Start build.
+ */
+Build.prototype.run = unyield(function *() {
+  // Run Plugins.
+  debug('plugins start');
+  yield this.plugins.run.call(this);
+  debug('plugins end');
 
-  // Clean dest folder
-  if (args.force) {
-    rimraf.sync(args.dest);
-  }
+  var files = this.files;
+  var args = this.args;
 
-  // Get files to build
-  var files = args.entry.length ? args.entry : getFiles(pkg);
-  log.info('output', 'files: ' + files);
+  // Stream Build
+  yield function(cb) {
+    pipe(
+      vfs.src(files, {cwd: args.cwd, cwdbase: true}),
 
-  // Check duplicate
-  var dups = getDuplicate(files, pkg);
-  for (var k in dups) {
-    log.warn('duplicate', '%s (%s) while build %s'.to.yellow.color,
-      k, dups[k].versions, dups[k].file.path);
-  }
-
-  // Include files in depenent packages
-  var depFilesMap;
-  if (args.withDeps) {
-    var dep = getDepFiles(pkg);
-    files = files.concat(dep.files);
-    depFilesMap = dep.filesMap;
-    log.info('withDeps', 'files: ' + files);
-  }
-
-  // Get extra deps
-  if (isFirst) {
-    var extraDeps = getExtraDeps(files, pkg, depFilesMap);
-    log.info('extra deps', extraDeps.length ? extraDeps.join(',') : 'no');
-    if (extraDeps && extraDeps.length) {
-      log.info('extra deps', 'install extra deps');
-      yield* client.install({
-        cwd: args.cwd,
-        registry: args.registry,
-        save: true,
-        name: extraDeps
-      });
-      yield* build(extend(args, {isFirstTime:false,install:false}));
-      return;
-    }
-  }
-
-  // Build with stream
-  yield buildThunk();
-
-  function buildThunk() {
-    return function(cb) {
-      pipe(
-        vfs.src(files, {cwd: args.cwd, cwdbase: true}),
-
-        mirror(
-          pipe(
-            // Transform
-            spm(args),
-            // Compress
-            _if(isJs, uglify(args.uglify)),
-            _if(isCSS, cssmin(args.cssmin)),
-            // Count size
-            size({gzip:true, showFiles:true, log:function(title, what, size) {
-              size = ((size/1024.0).toFixed(2) + 'kB').to.magenta;
-              log.info('size', what + ' ' + size + ' (gzipped)'.to.gray);
-            }})
-          ),
-
-          // debug version
-          pipe(
-            spm(extend({}, args, {rename: {suffix: '-debug'}}))
-          )
+      mirror(
+        pipe(
+          // Transform
+          spm(args),
+          // Compress
+          _if(utils.isJs, uglify(args.uglify)),
+          _if(utils.isCSS, cssmin(args.cssmin)),
+          // Count size
+          size({gzip:true, showFiles:true, log:function(title, what, size) {
+            size = ((size/1024.0).toFixed(2) + 'kB').to.magenta;
+            log.info('size', what + ' ' + size + ' (gzipped)'.to.gray);
+          }})
         ),
 
-        // Output files
-        vfs.dest(args.dest).on('data', function(file) {
-          log.info('generate file', relative(args.cwd, file.path));
-        }),
+        // debug version
+        pipe(
+          spm(extend({}, args, {rename: {suffix: '-debug'}}))
+        )
+      ),
 
-        // Zip files
-        _if(args.zip, pipe(zip('archive.zip'), vfs.dest(args.dest)))
-      )
-        .once('error', cb)
-        .once('end', cb)
-        .resume();
-    };
+      // Output files
+      vfs.dest(args.dest).on('data', function(file) {
+        log.info('generate file', relative(args.cwd, file.path));
+      }),
 
-    function isJs(file) {
-      return extname(file.path) === '.js';
+      // Zip files
+      _if(args.zip, pipe(zip('archive.zip'), vfs.dest(args.dest)))
+    )
+      .once('error', cb)
+      .once('end', cb)
+      .resume();
+  };
+});
+
+var Plugins = {
+
+  /**
+   * Merge args from arguments and spm.buildArgs in package.json.
+   */
+  getArgs: function() {
+    this.args = getArgs(this.opt);
+    logArgs(this.args);
+
+    // Try to generate package.json if entry is supplied
+    if (this.args.entry.length) {
+      generatePackageJSON(this.args);
+    }
+  },
+
+  /**
+   * Install deps.
+   */
+  installDeps: function* () {
+    var args = this.args;
+    if (args.entry.length) {
+      var deps = flatten(args.entry.map(function(item) {
+        return cdeps(join(args.cwd, item));
+      }));
+      log.info('entry deps', deps.join(', '));
+      yield* client.install({cwd:args.cwd, registry:args.registry, name:deps, save:true});
+    } else if (args.install) {
+      yield* client.install({cwd:args.cwd, registry:args.registry});
+    }
+  },
+
+  /**
+   * Parse pkg, files and dep files.
+   */
+  parsePkg: function* () {
+    var args = this.args;
+
+    // Parse pkg
+    var pkg = new Package(args.cwd, {
+      ignore: args.ignore,
+      skip: args.skip,
+      moduleDir: spmrc.get('install.path'),
+      entry: args.entry
+    });
+    args.pkg = pkg;
+    log.info('package', 'analyse infomation');
+    log.info('package', 'dependencies: ' + Object.keys(pkg.dependencies));
+    log.info('package', 'files: ' + Object.keys(pkg.files));
+
+    // Get files to build
+    var files = args.entry.length ? args.entry : getFiles(pkg);
+    log.info('output', 'files: ' + files);
+
+    // Check duplicate
+    var dups = getDuplicate(files, pkg);
+    for (var k in dups) {
+      log.warn('duplicate', '%s (%s) while build %s'.to.yellow.color,
+        k, dups[k].versions, dups[k].file.path);
     }
 
-    function isCSS(file) {
-      return extname(file.path) === '.css';
+    // Include files in dependent packages
+    var depFilesMap;
+    if (args.withDeps) {
+      var dep = getDepFiles(pkg);
+      files = files.concat(dep.files);
+      depFilesMap = dep.filesMap;
+      log.info('withDeps', 'files: ' + files);
+    }
+
+    this.files = files;
+    this.depFilesMap = depFilesMap;
+
+    // Get extra deps
+    if (!arguments[0]) {
+      var extraDeps = getExtraDeps(this.files, args.pkg, this.depFilesMap);
+      log.info('extra deps', extraDeps.length ? extraDeps.join(',') : 'no');
+      if (extraDeps && extraDeps.length) {
+        log.info('extra deps', 'install extra deps');
+        yield* client.install({
+          cwd: args.cwd,
+          registry: args.registry,
+          save: true,
+          name: extraDeps
+        });
+
+        // Call self to parse again
+        yield* Plugins.parsePkg.call(this, true);
+      }
+    }
+  },
+
+  /**
+   * Add clean task before build.
+   */
+  addCleanTask: function() {
+    var args = this.args;
+
+    // Clean dest folder
+    if (args.force) {
+      rimraf.sync(args.dest);
     }
   }
 };
 
-function logArgs(args) {
-  Object.keys(args).forEach(function(key) {
-    if (key === 'pkg' || key === '_') return;
-    var val = args[key];
-    if (typeof(val) === 'object') {
-      val = JSON.stringify(val);
-    }
-    log.info('arguments', key + ' = ' + val);
-  });
-}
+// Map plugins to proto
+Object.keys(Plugins).forEach(function(name) {
+  Build.prototype[name] = function() {
+    return this.use(Plugins[name]);
+  };
+});

--- a/lib/generatePackageJSON.js
+++ b/lib/generatePackageJSON.js
@@ -5,14 +5,14 @@ var basename = require('path').basename;
 var exists = require('fs').existsSync;
 var writeFile = require('fs').writeFileSync;
 
-module.exports = function(opt) {
-  var file = join(opt.cwd, 'package.json');
+module.exports = function(args) {
+  var file = join(args.cwd, 'package.json');
   if (exists(file)) {
     return;
   }
 
   var pkg = {
-    name: basename(opt.cwd),
+    name: basename(args.cwd),
     version: '0.1.0',
     spm: {}
   };

--- a/lib/getArgs.js
+++ b/lib/getArgs.js
@@ -52,7 +52,9 @@ function getGlobal(str) {
   var ret = {};
   str.split(/\s*,\s*/).forEach(function(item) {
     var m = item.split(':');
-    ret[m[0]] = m[1];
+    if (m[1]) {
+      ret[m[0]] = m[1].trim();
+    }
   });
   return ret;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,10 @@
+'use strict';
 
-exports.build = require('./build');
+exports.Build = require('./build');
 exports.getArgs = require('./getArgs');
+exports.logArgs = require('./logArgs');
 exports.getDepFiles = require('./getDepFiles');
 exports.getDuplicate = require('./getDuplicate');
 exports.getExtraDeps = require('./getExtraDeps');
 exports.getFiles = require('./getFiles');
+exports.utils = require('./utils');

--- a/lib/logArgs.js
+++ b/lib/logArgs.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var log = require('spm-log');
+
+module.exports = function(args) {
+  Object.keys(args).forEach(function(key) {
+    if (key === 'pkg' || key === '_') return;
+    var val = args[key];
+    if (typeof(val) === 'object') {
+      val = JSON.stringify(val);
+    }
+    log.info('arguments', key + ' = ' + val);
+  });
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var extname = require('path').extname;
+
+exports.isJs = function(file) {
+  return extname(file.path) === '.js';
+};
+
+exports.isCSS = function(file) {
+  return extname(file.path) === '.css';
+};

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "ali.gnode": "~0.1.1",
     "cdeps": "~0.1.0",
-    "co": "~4.0.1",
     "colorful": "~2.1.0",
     "commander": "~2.5.0",
+    "debug": "~2.1.1",
     "extend": "~2.0.0",
     "father": "~0.10.0",
     "flatten": "0.0.1",
@@ -26,7 +26,10 @@
     "spm-client": "~0.2.7",
     "spm-log": "~0.1.1",
     "spmrc": "~1.2.0",
+    "step.js": "~2.0.5",
+    "thunkify": "~2.1.2",
     "uniq": "~1.0.1",
+    "unyield": "0.0.1",
     "vinyl-fs": "~0.3.13"
   },
   "devDependencies": {

--- a/test/build.js
+++ b/test/build.js
@@ -6,8 +6,18 @@ var rimraf = require('rimraf');
 var join = require('path').join;
 var sinon = require('sinon');
 var log = require('spm-log');
+var thunkify = require('thunkify');
 
-var build = require('../lib/build');
+var Build = require('../lib/build');
+
+var build = thunkify(function(args, done) {
+  new Build(args)
+    .getArgs()
+    .installDeps()
+    .parsePkg()
+    .addCleanTask()
+    .run(done);
+});
 
 var fixtures = join(__dirname, 'fixtures');
 var dest = join(fixtures, 'tmp');
@@ -21,7 +31,7 @@ describe('lib/index.js', function() {
   });
 
   it('normal', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'normal'),
       dest: dest,
       install: true
@@ -30,7 +40,7 @@ describe('lib/index.js', function() {
   });
 
   it('normal withDeps', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'normal'),
       dest: dest,
       withDeps: true,
@@ -40,7 +50,7 @@ describe('lib/index.js', function() {
   });
 
   it('normal ignore', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'normal'),
       dest: dest,
       ignore: 'type',
@@ -50,7 +60,7 @@ describe('lib/index.js', function() {
   });
 
   it('normal standalone', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'normal'),
       dest: dest,
       include: 'standalone',
@@ -60,7 +70,7 @@ describe('lib/index.js', function() {
   });
 
   it('normal standalone ignore', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'normal'),
       dest: dest,
       ignore: 'type',
@@ -71,7 +81,7 @@ describe('lib/index.js', function() {
   });
 
   it('normal umd', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'normal'),
       dest: dest,
       include: 'umd',
@@ -81,7 +91,7 @@ describe('lib/index.js', function() {
   });
 
   it('normal empty idleading', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'normal'),
       dest: dest,
       idleading: '',
@@ -91,7 +101,7 @@ describe('lib/index.js', function() {
   });
 
   it('normal global', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'normal'),
       dest: dest,
       global: 'type: Type',
@@ -101,7 +111,7 @@ describe('lib/index.js', function() {
   });
 
   it('nodeps ignore', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'nodeps-ignore'),
       dest: dest,
       ignore: 'jquery',
@@ -112,7 +122,7 @@ describe('lib/index.js', function() {
 
   it('multiple versions', function* () {
     var logWarn = sinon.spy(log, 'warn');
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'multiple-versions'),
       dest: dest,
       install: false
@@ -122,7 +132,7 @@ describe('lib/index.js', function() {
   });
 
   it('css package', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'css-package'),
       dest: dest,
       install: false
@@ -131,7 +141,7 @@ describe('lib/index.js', function() {
   });
 
   it('package file', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'package-file'),
       dest: dest,
       install: false
@@ -146,7 +156,7 @@ describe('lib/index.js', function() {
     });
 
     it('extra deps', function* () {
-      yield *build({
+      yield build({
         cwd: join(fixtures, 'extra-deps'),
         dest: dest,
         install: false
@@ -156,7 +166,7 @@ describe('lib/index.js', function() {
   });
 
   it('entry', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'entry'),
       dest: dest,
       install: false,
@@ -172,7 +182,7 @@ describe('lib/index.js', function() {
     });
 
     it('entry without pkg', function* () {
-      yield *build({
+      yield build({
         cwd: join(fixtures, 'entry-without-pkg'),
         dest: dest,
         install: false,
@@ -184,7 +194,7 @@ describe('lib/index.js', function() {
   });
 
   it('copy img', function* () {
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'copy-img'),
       dest: dest,
       install: false
@@ -197,7 +207,7 @@ describe('lib/index.js', function() {
     fs.mkdirSync(dest);
     fs.writeFileSync(fakeFile);
 
-    yield *build({
+    yield build({
       cwd: join(fixtures, 'normal'),
       dest: dest,
       force: true,

--- a/test/expected/normal-global/a/0.1.0/a-debug.js
+++ b/test/expected/normal-global/a/0.1.0/a-debug.js
@@ -1,5 +1,5 @@
 define("a/0.1.0/a-debug", [], function(require, exports, module){
- Type;
+window.Type;
 console.log("a@0.1.0");
 
 });

--- a/test/expected/normal-global/a/0.1.0/a.js
+++ b/test/expected/normal-global/a/0.1.0/a.js
@@ -1,1 +1,1 @@
-define("a/0.1.0/a",[],function(){console.log("a@0.1.0")});
+define("a/0.1.0/a",[],function(){window.Type,console.log("a@0.1.0")});


### PR DESCRIPTION
把任务通过接口暴露出来，内网构建可基于此进行扩展。

```javascript
Build(opts)
  .getArgs()
  .installDeps()
  .parsePkg()
  .addCleanTask()
  .run(function(err) {
    if (err) console.log(err.stack);
    else console.log('done');
  });
```
