### PR TITLE
fix: filter the files that not matched by spm.output

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -335,15 +335,14 @@ function distConfig(options, pkg) {
       {
         expand: true,
         cwd: '.build/src',
-        src: '**/*.*',
+        src: ['**/*.*','!**/*.css', '!**/*.js'],
         filter: function(src) {
           // filter the file that is surfix by .css and .js and 
           // keep the file that are match by spm.output
-          var excludejsAndCss = !/\.(js|css)$/.test(src);
           var filesMatchSpmOutput = Object.keys(output).some(function(file) {
             return new RegExp(file).test(src);
           });
-          return excludejsAndCss && filesMatchSpmOutput;
+          return filesMatchSpmOutput;
         },
         dest: '.build/dist'
       }

--- a/lib/config.js
+++ b/lib/config.js
@@ -337,7 +337,13 @@ function distConfig(options, pkg) {
         cwd: '.build/src',
         src: '**/*.*',
         filter: function(src) {
-          return !/\.(js|css)$/.test(src);
+          // filter the file that is surfix by .css and .js and 
+          // keep the file that are match by spm.output
+          var excludejsAndCss = !/\.(js|css)$/.test(src);
+          var filesMatchSpmOutput = Object.keys(output).some(function(file) {
+            return new RegExp(file).test(src);
+          });
+          return excludejsAndCss && filesMatchSpmOutput;
         },
         dest: '.build/dist'
       }


### PR DESCRIPTION
when copy files from .build/src to .build/dist, we need to exclude the
files that are not matched by spm.output

otherwise, all files that not surfix by js or css will be copied to dist/